### PR TITLE
 main menu attributes updated

### DIFF
--- a/packages/backend/src/components/header/main-menu.json
+++ b/packages/backend/src/components/header/main-menu.json
@@ -2,12 +2,66 @@
   "collectionName": "components_header_main_menus",
   "info": {
     "displayName": "Main Menu",
-    "icon": "arrowRight"
+    "icon": "layout",
+    "description": "Main Menu"
   },
+  "category": "header",
+  "modelName": "main-menu",
+  "globalId": "ComponentsHeaderMainMenus",
+  "uid": "header.main-menu",
+  "modelType": "component",
   "options": {},
+  "pluginOptions": {},
   "attributes": {
-    "title": {
-      "type": "string"
+    "light_logo": {
+      "type": "component",
+      "repeatable": false,
+      "component": "header.logo"
+    },
+    "dark_logo": {
+      "type": "component",
+      "repeatable": false,
+      "component": "header.logo"
+    },
+    "dark_mode": {
+      "type": "boolean",
+      "default": true,
+      "required": true
+    },
+    "notification": {
+      "type": "boolean",
+      "default": true,
+      "required": true
+    },
+    "main_menu": {
+      "type": "component",
+      "repeatable": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "config.menu"
+    },
+    "langague": {
+      "type": "component",
+      "repeatable": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "component": "component.link"
+    },
+    "button": {
+      "type": "component",
+      "repeatable": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "component.link"
     }
   }
 }

--- a/packages/backend/types/generated/components.d.ts
+++ b/packages/backend/types/generated/components.d.ts
@@ -34,7 +34,7 @@ export interface BlockBlogCard extends Struct.ComponentSchema {
   };
   attributes: {
     button: Schema.Attribute.Component<'component.link', false>;
-    content: Schema.Attribute.Component<'config.section-title', true>;
+    content: Schema.Attribute.Component<'config.section-title', false>;
     empty: Schema.Attribute.Component<'shared.empty', false>;
     posts: Schema.Attribute.Relation<'oneToMany', 'plugin::padma-backend.post'>;
     style: Schema.Attribute.Component<'component.style-section', false>;
@@ -71,7 +71,7 @@ export interface BlockCategoryCard extends Struct.ComponentSchema {
       'oneToMany',
       'plugin::padma-backend.category'
     >;
-    content: Schema.Attribute.Component<'config.section-title', true>;
+    content: Schema.Attribute.Component<'config.section-title', false>;
     empty: Schema.Attribute.Component<'shared.empty', false>;
     style: Schema.Attribute.Component<'component.style-section', false>;
   };
@@ -199,7 +199,7 @@ export interface BlockReviewBlock extends Struct.ComponentSchema {
   };
   attributes: {
     button: Schema.Attribute.Component<'component.link', false>;
-    content: Schema.Attribute.Component<'config.section-title', true>;
+    content: Schema.Attribute.Component<'config.section-title', false>;
     empty: Schema.Attribute.Component<'shared.empty', false>;
     reviews: Schema.Attribute.Component<'config.review-card', true>;
     style: Schema.Attribute.Component<'component.style-section', false>;
@@ -892,11 +892,37 @@ export interface HeaderLogo extends Struct.ComponentSchema {
 export interface HeaderMainMenu extends Struct.ComponentSchema {
   collectionName: 'components_header_main_menus';
   info: {
+    description: 'Main Menu';
     displayName: 'Main Menu';
-    icon: 'arrowRight';
+    icon: 'layout';
   };
   attributes: {
-    title: Schema.Attribute.String;
+    button: Schema.Attribute.Component<'component.link', true> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    dark_logo: Schema.Attribute.Component<'header.logo', false>;
+    dark_mode: Schema.Attribute.Boolean &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<true>;
+    langague: Schema.Attribute.Component<'component.link', true> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false;
+        };
+      }>;
+    light_logo: Schema.Attribute.Component<'header.logo', false>;
+    main_menu: Schema.Attribute.Component<'config.menu', true> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    notification: Schema.Attribute.Boolean &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<true>;
   };
 }
 


### PR DESCRIPTION

# Main Attributes

The `main` accepts the following attributes:

1. **light_logo**  
   - **Type**: Component  
   - **Repeatable**: No  
   - **Component**: `header.logo`

2. **dark_logo**  
   - **Type**: Component  
   - **Repeatable**: No  
   - **Component**: `header.logo`

3. **dark_mode**  
   - **Type**: Boolean  
   - **Default**: `true`  
   - **Required**: Yes  

4. **notification**  
   - **Type**: Boolean  
   - **Default**: `true`  
   - **Required**: Yes  

5. **main_menu**  
   - **Type**: Component  
   - **Repeatable**: Yes  
   - **Plugin Options**: 
     - i18n: Localized (`true`)  
   - **Component**: `config.menu`

6. **langague**  
   - **Type**: Component  
   - **Repeatable**: Yes  
   - **Plugin Options**: 
     - i18n: Localized (`false`)  
   - **Component**: `component.link`

7. **button**  
   - **Type**: Component  
   - **Repeatable**: Yes  
   - **Plugin Options**: 
     - i18n: Localized (`true`)  
   - **Component**: `component.link`